### PR TITLE
Enhance location picker with map search

### DIFF
--- a/frontend/components/location-picker.ts
+++ b/frontend/components/location-picker.ts
@@ -1,6 +1,6 @@
 /// <reference path="../types/assets.d.ts" />
 import { LitElement, html } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import * as L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
@@ -22,6 +22,27 @@ export class LocationPicker extends LitElement {
   private marker?: L.Marker;
   private resizeObserver?: ResizeObserver;
   private searchController?: AbortController;
+
+  @property({ type: String })
+  searchPlaceholder = '';
+
+  @property({ type: String })
+  searchLabel = '';
+
+  @property({ type: String })
+  searchingLabel = '';
+
+  @property({ type: String })
+  noResultsLabel = '';
+
+  @property({ type: String })
+  fetchErrorLabel = '';
+
+  @property({ type: String })
+  noSelectionLabel = '';
+
+  @property({ type: String })
+  selectedLabel = '';
 
   @state()
   private selectedLat: number | null = null;
@@ -151,13 +172,13 @@ export class LocationPicker extends LitElement {
         <div class="search-bar">
           <input
             type="text"
-            placeholder="Search for a place"
+            placeholder=${this.searchPlaceholder}
             .value=${this.searchQuery}
             @input=${this.handleSearchInput}
             @keydown=${this.handleSearchKeydown}
           />
           <button @click=${this.performSearch} ?disabled=${this.searching || this.searchQuery.trim().length < 3}>
-            ${this.searching ? 'Searching…' : 'Search'}
+            ${this.searching ? this.searchingLabel : this.searchLabel}
           </button>
         </div>
         ${this.searchError ? html`<div class="error">${this.searchError}</div>` : ''}
@@ -174,8 +195,8 @@ export class LocationPicker extends LitElement {
           : ''}
         <div class="status">
           ${this.selectedLat !== null && this.selectedLng !== null
-            ? html`Selected location: ${this.selectedLat.toFixed(5)}, ${this.selectedLng.toFixed(5)}`
-            : 'No location selected yet.'}
+            ? html`${this.selectedLabel} ${this.selectedLat.toFixed(5)}, ${this.selectedLng.toFixed(5)}`
+            : this.noSelectionLabel}
         </div>
         <div id="map"></div>
       </div>
@@ -234,7 +255,7 @@ export class LocationPicker extends LitElement {
       });
 
       if (!response.ok) {
-        throw new Error('Search failed');
+        throw new Error();
       }
 
       const payload = (await response.json()) as Array<{ lat: string; lon: string; display_name: string }>;
@@ -248,13 +269,13 @@ export class LocationPicker extends LitElement {
 
       this.searchResults = mapped;
       if (mapped.length === 0) {
-        this.searchError = 'No results found.';
+        this.searchError = this.noResultsLabel;
       }
     } catch (err: any) {
       if (err?.name === 'AbortError') {
         return;
       }
-      this.searchError = 'Unable to fetch locations. Please try again.';
+      this.searchError = this.fetchErrorLabel;
     } finally {
       this.searching = false;
     }

--- a/frontend/components/location-picker.ts
+++ b/frontend/components/location-picker.ts
@@ -1,6 +1,6 @@
 /// <reference path="../types/assets.d.ts" />
 import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, state } from 'lit/decorators.js';
 import * as L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 
@@ -18,37 +18,282 @@ import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 
 @customElement('location-picker')
 export class LocationPicker extends LitElement {
+  private map?: L.Map;
+  private marker?: L.Marker;
+  private resizeObserver?: ResizeObserver;
+  private searchController?: AbortController;
+
+  @state()
+  private selectedLat: number | null = null;
+
+  @state()
+  private selectedLng: number | null = null;
+
+  @state()
+  private searchQuery = '';
+
+  @state()
+  private searching = false;
+
+  @state()
+  private searchError: string | null = null;
+
+  @state()
+  private searchResults: Array<{ displayName: string; lat: number; lng: number }> = [];
+
   createRenderRoot() { return this; }
 
   firstUpdated() {
-    const mapDiv = this.querySelector('#map') as HTMLElement;
-    const map = L.map(mapDiv).setView([35.6892, 51.3890], 11);
+    const mapDiv = this.querySelector('#map') as HTMLElement | null;
+    if (!mapDiv) {
+      return;
+    }
+
+    this.map = L.map(mapDiv).setView([35.6892, 51.3890], 11);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; OpenStreetMap contributors',
       maxZoom: 19
-    }).addTo(map);
+    }).addTo(this.map);
 
-    let marker: L.Marker | null = null;
+    this.map.on('click', (ev: L.LeafletMouseEvent) => {
+      this.setLocation(ev.latlng.lat, ev.latlng.lng);
+    });
 
-    const setLoc = (lat: number, lng: number) => {
-      if (marker) {
-        marker.setLatLng([lat, lng]);
-      } else {
-        marker = L.marker([lat, lng], { draggable: true }).addTo(map);
-        marker.on('dragend', () => {
-          const pos = marker!.getLatLng();
-          // @ts-ignore Flow bridge
-          this.$server.setLocation(pos.lat, pos.lng);
-        });
-      }
-      // @ts-ignore Flow bridge
-      this.$server.setLocation(lat, lng);
-    };
+    this.resizeObserver = new ResizeObserver(() => {
+      this.map?.invalidateSize();
+    });
+    this.resizeObserver.observe(this);
 
-    map.on('click', (ev: any) => setLoc(ev.latlng.lat, ev.latlng.lng));
+    setTimeout(() => {
+      this.map?.invalidateSize();
+    }, 0);
   }
 
   render() {
-    return html`<div id="map" style="height: 500px; width: 100%"></div>`;
+    return html`
+      <style>
+        .picker-container {
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          width: 100%;
+        }
+
+        .search-bar {
+          display: flex;
+          gap: 0.5rem;
+          align-items: center;
+        }
+
+        .search-bar input[type="text"] {
+          flex: 1;
+          padding: 0.35rem 0.5rem;
+          border: 1px solid var(--lumo-contrast-30pct, #c3c3c3);
+          border-radius: 4px;
+          font: inherit;
+        }
+
+        .search-bar button {
+          padding: 0.35rem 0.75rem;
+          border-radius: 4px;
+          border: none;
+          background: var(--lumo-primary-color, #2e7d32);
+          color: white;
+          font-weight: 600;
+          cursor: pointer;
+        }
+
+        .search-bar button[disabled] {
+          opacity: 0.6;
+          cursor: default;
+        }
+
+        .results {
+          list-style: none;
+          padding: 0;
+          margin: 0;
+          border: 1px solid var(--lumo-contrast-30pct, #c3c3c3);
+          border-radius: 4px;
+          max-height: 160px;
+          overflow-y: auto;
+        }
+
+        .results li button {
+          width: 100%;
+          padding: 0.5rem;
+          background: white;
+          border: none;
+          text-align: left;
+          cursor: pointer;
+        }
+
+        .results li button:hover,
+        .results li button:focus {
+          background: var(--lumo-contrast-10pct, #f0f0f0);
+        }
+
+        .status {
+          font-size: 0.9rem;
+          color: var(--lumo-secondary-text-color, #555);
+        }
+
+        .error {
+          color: var(--lumo-error-text-color, #b00020);
+          font-size: 0.85rem;
+        }
+
+        #map {
+          height: 500px;
+          width: 100%;
+        }
+      </style>
+      <div class="picker-container">
+        <div class="search-bar">
+          <input
+            type="text"
+            placeholder="Search for a place"
+            .value=${this.searchQuery}
+            @input=${this.handleSearchInput}
+            @keydown=${this.handleSearchKeydown}
+          />
+          <button @click=${this.performSearch} ?disabled=${this.searching || this.searchQuery.trim().length < 3}>
+            ${this.searching ? 'Searching…' : 'Search'}
+          </button>
+        </div>
+        ${this.searchError ? html`<div class="error">${this.searchError}</div>` : ''}
+        ${this.searchResults.length > 0
+          ? html`<ul class="results">
+              ${this.searchResults.map(
+                res => html`<li>
+                  <button type="button" @click=${() => this.handleResultSelect(res)}>
+                    ${res.displayName}
+                  </button>
+                </li>`
+              )}
+            </ul>`
+          : ''}
+        <div class="status">
+          ${this.selectedLat !== null && this.selectedLng !== null
+            ? html`Selected location: ${this.selectedLat.toFixed(5)}, ${this.selectedLng.toFixed(5)}`
+            : 'No location selected yet.'}
+        </div>
+        <div id="map"></div>
+      </div>
+    `;
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.map) {
+      this.map.remove();
+      this.map = undefined;
+    }
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = undefined;
+    }
+    if (this.searchController) {
+      this.searchController.abort();
+      this.searchController = undefined;
+    }
+  }
+
+  private handleSearchInput(ev: Event) {
+    this.searchQuery = (ev.target as HTMLInputElement).value;
+  }
+
+  private handleSearchKeydown(ev: KeyboardEvent) {
+    if (ev.key === 'Enter') {
+      ev.preventDefault();
+      this.performSearch();
+    }
+  }
+
+  private async performSearch() {
+    const query = this.searchQuery.trim();
+    if (query.length < 3 || this.searching) {
+      return;
+    }
+
+    if (this.searchController) {
+      this.searchController.abort();
+    }
+    this.searchController = new AbortController();
+
+    this.searching = true;
+    this.searchError = null;
+    this.searchResults = [];
+
+    try {
+      const url = `https://nominatim.openstreetmap.org/search?format=json&q=${encodeURIComponent(query)}&limit=5`;
+      const response = await fetch(url, {
+        headers: {
+          Accept: 'application/json'
+        },
+        signal: this.searchController.signal
+      });
+
+      if (!response.ok) {
+        throw new Error('Search failed');
+      }
+
+      const payload = (await response.json()) as Array<{ lat: string; lon: string; display_name: string }>;
+      const mapped = payload
+        .map(item => ({
+          displayName: item.display_name,
+          lat: Number.parseFloat(item.lat),
+          lng: Number.parseFloat(item.lon)
+        }))
+        .filter(item => Number.isFinite(item.lat) && Number.isFinite(item.lng));
+
+      this.searchResults = mapped;
+      if (mapped.length === 0) {
+        this.searchError = 'No results found.';
+      }
+    } catch (err: any) {
+      if (err?.name === 'AbortError') {
+        return;
+      }
+      this.searchError = 'Unable to fetch locations. Please try again.';
+    } finally {
+      this.searching = false;
+    }
+  }
+
+  private handleResultSelect(result: { displayName: string; lat: number; lng: number }) {
+    this.searchQuery = result.displayName;
+    this.searchResults = [];
+    this.setLocation(result.lat, result.lng);
+  }
+
+  private setLocation(lat: number, lng: number) {
+    if (!this.map) {
+      return;
+    }
+
+    if (!this.marker) {
+      this.marker = L.marker([lat, lng], { draggable: true }).addTo(this.map);
+      this.marker.on('dragend', () => {
+        const pos = this.marker?.getLatLng();
+        if (pos) {
+          this.updateSelected(pos.lat, pos.lng);
+        }
+      });
+    } else {
+      this.marker.setLatLng([lat, lng]);
+    }
+
+    this.map.setView([lat, lng], Math.max(this.map.getZoom(), 13));
+    this.updateSelected(lat, lng);
+  }
+
+  private updateSelected(lat: number, lng: number) {
+    this.selectedLat = lat;
+    this.selectedLng = lng;
+    // @ts-ignore Flow bridge
+    if (this.$server && typeof this.$server.setLocation === 'function') {
+      // @ts-ignore Flow bridge
+      this.$server.setLocation(lat, lng);
+    }
   }
 }

--- a/src/main/java/com/example/adminpanel/component/FilterablePaginatedGrid.java
+++ b/src/main/java/com/example/adminpanel/component/FilterablePaginatedGrid.java
@@ -93,7 +93,7 @@ public class FilterablePaginatedGrid<T> extends VerticalLayout implements Locale
     private final boolean usePageResult;
     private final Map<String, String> filters = new HashMap<>();
     private final Map<String, Component> filterComponents = new HashMap<>();
-    private final java.util.Map<com.vaadin.flow.component.formlayout.FormLayout.FormItem, String> filterLabelKeys = new java.util.LinkedHashMap<>();
+    private final java.util.Map<com.vaadin.flow.component.HasText, String> filterLabelKeys = new java.util.LinkedHashMap<>();
     private final com.vaadin.flow.component.dialog.Dialog filterDialog = new com.vaadin.flow.component.dialog.Dialog();
     private final Button filterButton = new Button();
 
@@ -451,9 +451,9 @@ public class FilterablePaginatedGrid<T> extends VerticalLayout implements Locale
                     tf.setClearButtonVisible(true);
                     tf.setPlaceholder(getTranslation("grid.filterPlaceholder"));
                     filterComponents.put(def.getPropertyName(), tf);
-                    com.vaadin.flow.component.formlayout.FormLayout.FormItem item =
-                            formLayout.addFormItem(tf, getTranslation(def.getLabelKey()));
-                    filterLabelKeys.put(item, def.getLabelKey());
+                    com.vaadin.flow.component.html.Span label = new com.vaadin.flow.component.html.Span(getTranslation(def.getLabelKey()));
+                    formLayout.addFormItem(tf, label);
+                    filterLabelKeys.put(label, def.getLabelKey());
                 }
                 case NUMBER_RANGE -> {
                     // Two integer fields: min and max
@@ -468,9 +468,9 @@ public class FilterablePaginatedGrid<T> extends VerticalLayout implements Locale
                     com.vaadin.flow.component.orderedlayout.HorizontalLayout rangeLayout = new com.vaadin.flow.component.orderedlayout.HorizontalLayout(minField, maxField);
                     rangeLayout.setWidthFull();
                     rangeLayout.setSpacing(true);
-                    com.vaadin.flow.component.formlayout.FormLayout.FormItem item =
-                            formLayout.addFormItem(rangeLayout, getTranslation(def.getLabelKey()));
-                    filterLabelKeys.put(item, def.getLabelKey());
+                    com.vaadin.flow.component.html.Span label = new com.vaadin.flow.component.html.Span(getTranslation(def.getLabelKey()));
+                    formLayout.addFormItem(rangeLayout, label);
+                    filterLabelKeys.put(label, def.getLabelKey());
                 }
                 case DATE_RANGE -> {
                     com.vaadin.flow.component.datepicker.DatePicker from = new com.vaadin.flow.component.datepicker.DatePicker();
@@ -482,9 +482,9 @@ public class FilterablePaginatedGrid<T> extends VerticalLayout implements Locale
                     com.vaadin.flow.component.orderedlayout.HorizontalLayout dateLayout = new com.vaadin.flow.component.orderedlayout.HorizontalLayout(from, to);
                     dateLayout.setWidthFull();
                     dateLayout.setSpacing(true);
-                    com.vaadin.flow.component.formlayout.FormLayout.FormItem item =
-                            formLayout.addFormItem(dateLayout, getTranslation(def.getLabelKey()));
-                    filterLabelKeys.put(item, def.getLabelKey());
+                    com.vaadin.flow.component.html.Span label = new com.vaadin.flow.component.html.Span(getTranslation(def.getLabelKey()));
+                    formLayout.addFormItem(dateLayout, label);
+                    filterLabelKeys.put(label, def.getLabelKey());
                 }
                 case SELECT -> {
                     com.vaadin.flow.component.combobox.ComboBox<String> cb = new com.vaadin.flow.component.combobox.ComboBox<>();
@@ -492,9 +492,9 @@ public class FilterablePaginatedGrid<T> extends VerticalLayout implements Locale
                     cb.setItems(def.getOptions());
                     cb.setClearButtonVisible(true);
                     filterComponents.put(def.getPropertyName(), cb);
-                    com.vaadin.flow.component.formlayout.FormLayout.FormItem item =
-                            formLayout.addFormItem(cb, getTranslation(def.getLabelKey()));
-                    filterLabelKeys.put(item, def.getLabelKey());
+                    com.vaadin.flow.component.html.Span label = new com.vaadin.flow.component.html.Span(getTranslation(def.getLabelKey()));
+                    formLayout.addFormItem(cb, label);
+                    filterLabelKeys.put(label, def.getLabelKey());
                     selectComponents.put(def.getPropertyName(), cb);
                 }
             }
@@ -805,7 +805,7 @@ public class FilterablePaginatedGrid<T> extends VerticalLayout implements Locale
             col.setHeader(getTranslation(def.getHeaderKey()));
         }
 
-        filterLabelKeys.forEach((item, key) -> item.setLabel(getTranslation(key)));
+        filterLabelKeys.forEach((label, key) -> label.setText(getTranslation(key)));
 
         filterComponents.forEach((key, comp) -> {
             if (comp instanceof TextField tf) {

--- a/src/main/java/com/example/adminpanel/component/FilterablePaginatedGrid.java
+++ b/src/main/java/com/example/adminpanel/component/FilterablePaginatedGrid.java
@@ -41,6 +41,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 import com.example.adminpanel.component.PageResult;
 import com.example.adminpanel.component.PageResultService;
@@ -785,9 +787,13 @@ public class FilterablePaginatedGrid<T> extends VerticalLayout implements Locale
     private void updatePageInfo() {
         int from = totalCount == 0 ? 0 : currentPage * pageSize + 1;
         int to = Math.min((currentPage + 1) * pageSize, totalCount);
-        int totalPages = (int) Math.ceil((double) totalCount / pageSize);
-        if (totalPages == 0) totalPages = 1;
-        pageInfo.setText(getTranslation("grid.pageInfo", from, to, totalCount));
+        UI ui = UI.getCurrent();
+        Locale locale = ui != null ? ui.getLocale() : Locale.getDefault();
+        NumberFormat integerFormat = NumberFormat.getIntegerInstance(locale);
+        String fromText = integerFormat.format(from);
+        String toText = integerFormat.format(to);
+        String totalText = integerFormat.format(totalCount);
+        pageInfo.setText(getTranslation("grid.pageInfo", fromText, toText, totalText));
     }
 
     private void applyTranslations() {

--- a/src/main/java/com/example/adminpanel/component/LocationPicker.java
+++ b/src/main/java/com/example/adminpanel/component/LocationPicker.java
@@ -2,22 +2,46 @@ package com.example.adminpanel.component;
 
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.shared.Registration;
 
 @Tag("location-picker")
 @NpmPackage(value = "leaflet", version = "1.9.4")
 @NpmPackage(value = "@types/leaflet", version = "1.9.7")
 @JsModule("./components/location-picker.ts")
-public class LocationPicker extends Component {
+public class LocationPicker extends Component implements LocaleChangeObserver {
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        applyTranslations();
+    }
 
     @ClientCallable
     private void setLocation(double lat, double lng) {
         fireEvent(new LocationSelectedEvent(this, lat, lng));
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        applyTranslations();
+    }
+
+    private void applyTranslations() {
+        getElement().setProperty("searchPlaceholder", getTranslation("form.location.searchPlaceholder"));
+        getElement().setProperty("searchLabel", getTranslation("form.location.search"));
+        getElement().setProperty("searchingLabel", getTranslation("form.location.searching"));
+        getElement().setProperty("noResultsLabel", getTranslation("form.location.noResults"));
+        getElement().setProperty("fetchErrorLabel", getTranslation("form.location.fetchError"));
+        getElement().setProperty("noSelectionLabel", getTranslation("form.location.noSelection"));
+        getElement().setProperty("selectedLabel", getTranslation("form.location.selectedLabel"));
     }
 
     public Registration addLocationSelectedListener(ComponentEventListener<LocationSelectedEvent> l) {

--- a/src/main/java/com/example/adminpanel/i18n/TranslationProvider.java
+++ b/src/main/java/com/example/adminpanel/i18n/TranslationProvider.java
@@ -3,6 +3,7 @@ package com.example.adminpanel.i18n;
 import com.vaadin.flow.i18n.I18NProvider;
 import org.springframework.stereotype.Component;
 
+import java.text.MessageFormat;
 import java.util.*;
 
 /**
@@ -49,7 +50,8 @@ public class TranslationProvider implements I18NProvider {
             value = key;
         }
         if (params != null && params.length > 0) {
-            value = String.format(locale, value, params);
+            MessageFormat formatter = new MessageFormat(value, locale);
+            value = formatter.format(params);
         }
         return value;
     }

--- a/src/main/java/com/example/adminpanel/view/CompactGridView.java
+++ b/src/main/java/com/example/adminpanel/view/CompactGridView.java
@@ -5,8 +5,10 @@ import com.example.adminpanel.component.FilterDefinition;
 import com.example.adminpanel.component.FilterablePaginatedGrid;
 import com.example.adminpanel.model.Person;
 import com.example.adminpanel.service.MockPersonService;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.router.Route;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -19,34 +21,34 @@ import java.util.List;
  * are many rows, it will scroll within the specified maximum height.
  */
 @Route(value = "compact-grid", layout = MainLayout.class)
-@PageTitle("Compact Grid")
-public class CompactGridView extends VerticalLayout {
+public class CompactGridView extends VerticalLayout implements LocaleChangeObserver {
 
     @Autowired
     public CompactGridView(MockPersonService personService) {
         setSizeFull();
         setPadding(true);
         initTable(personService);
+        updatePageTitle();
     }
 
     private void initTable(MockPersonService personService) {
         // Define columns
         List<ColumnDefinition> columns = List.of(
-                new ColumnDefinition("firstName", "First Name", String.class),
-                new ColumnDefinition("lastName", "Last Name", String.class),
-                new ColumnDefinition("email", "Email", String.class),
-                new ColumnDefinition("age", "Age", Integer.class)
+                new ColumnDefinition("firstName", "person.firstName", String.class),
+                new ColumnDefinition("lastName", "person.lastName", String.class),
+                new ColumnDefinition("email", "person.email", String.class),
+                new ColumnDefinition("age", "person.age", Integer.class)
         );
         // Define filters similar to FullGridView
         List<FilterDefinition> filters = List.of(
-                new FilterDefinition("firstName", "First Name", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("lastName", "Last Name", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("email", "Email", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("age", "Age", FilterDefinition.FilterType.NUMBER_RANGE, Integer.class),
-                new FilterDefinition("country", "Country", List.of("USA", "UK", "Iran"), null),
+                new FilterDefinition("firstName", "person.firstName", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("lastName", "person.lastName", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("email", "person.email", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("age", "person.age", FilterDefinition.FilterType.NUMBER_RANGE, Integer.class),
+                new FilterDefinition("country", "person.country", List.of("USA", "UK", "Iran"), null),
                 new FilterDefinition(
                         "city",
-                        "City",
+                        "person.city",
                         List.of(
                                 "USA|New York",
                                 "USA|Los Angeles",
@@ -65,5 +67,17 @@ public class CompactGridView extends VerticalLayout {
         grid.setMaxHeight("400px");
         add(grid);
         // Do not call expand(grid) so that height constraints are respected
+    }
+
+    private void updatePageTitle() {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            ui.getPage().setTitle(getTranslation("compactGrid.title"));
+        }
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        updatePageTitle();
     }
 }

--- a/src/main/java/com/example/adminpanel/view/DesignSystemView.java
+++ b/src/main/java/com/example/adminpanel/view/DesignSystemView.java
@@ -1,42 +1,65 @@
 package com.example.adminpanel.view;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.router.Route;
 
-@PageTitle("Design System")
 @Route(value = "design-system", layout = MainLayout.class)
-public class DesignSystemView extends VerticalLayout {
+public class DesignSystemView extends VerticalLayout implements LocaleChangeObserver {
+
+    private final H2 heading;
+    private final H2 buttonsTitle;
+    private final H2 badgesTitle;
+    private final Button primaryButton;
+    private final Button secondaryButton;
+    private final Button infoButton;
+    private final Button successButton;
+    private final Button warningButton;
+    private final Button dangerButton;
+    private final Span primaryBadge;
+    private final Span secondaryBadge;
+    private final Span infoBadge;
+    private final Span successBadge;
+    private final Span warningBadge;
+    private final Span dangerBadge;
 
     public DesignSystemView() {
         setSpacing(true);
         setPadding(true);
         setWidthFull();
-        add(new H2("پیش‌نمایش رنگ‌ها / Design System"));
+        heading = new H2();
+        add(heading);
 
-        // Buttons (responsive grid)
         Div buttons = responsiveGrid();
-        buttons.add(btn("Primary", "primary"),
-                    btn("Secondary", "secondary"),
-                    btn("Info", "info"),
-                    btn("Success", "success"),
-                    btn("Warning", "warning"),
-                    btn("Danger", "danger"));
-        add(card("دکمه‌ها / Buttons", buttons));
+        primaryButton = btn("primary");
+        secondaryButton = btn("secondary");
+        infoButton = btn("info");
+        successButton = btn("success");
+        warningButton = btn("warning");
+        dangerButton = btn("danger");
+        buttons.add(primaryButton, secondaryButton, infoButton, successButton, warningButton, dangerButton);
+        buttonsTitle = new H2();
+        add(card(buttonsTitle, buttons));
 
-        // Badges (responsive grid)
         Div badges = responsiveGrid();
-        badges.add(badge("primary", "Primary"),
-                   badge("secondary", "Secondary"),
-                   badge("info", "Info"),
-                   badge("success", "Success"),
-                   badge("warning", "Warning"),
-                   badge("danger", "Danger"));
-        add(card("نشان‌ها / Badges", badges));
+        primaryBadge = badge("primary");
+        secondaryBadge = badge("secondary");
+        infoBadge = badge("info");
+        successBadge = badge("success");
+        warningBadge = badge("warning");
+        dangerBadge = badge("danger");
+        badges.add(primaryBadge, secondaryBadge, infoBadge, successBadge, warningBadge, dangerBadge);
+        badgesTitle = new H2();
+        add(card(badgesTitle, badges));
+
+        updateTexts();
+        updatePageTitle();
     }
 
     private Div responsiveGrid() {
@@ -48,28 +71,59 @@ public class DesignSystemView extends VerticalLayout {
         return grid;
     }
 
-    private Button btn(String text, String themeName) {
-        Button b = new Button(text);
+    private Button btn(String themeName) {
+        Button b = new Button();
         b.getElement().setAttribute("theme", themeName);
         b.setWidthFull();
         return b;
     }
 
-    private Span badge(String theme, String text) {
-        Span s = new Span(text);
+    private Span badge(String theme) {
+        Span s = new Span();
         s.getElement().setAttribute("theme", "badge");
         s.getElement().getClassList().add(theme);
         return s;
     }
 
-    private VerticalLayout card(String title, com.vaadin.flow.component.Component content) {
+    private VerticalLayout card(H2 title, com.vaadin.flow.component.Component content) {
         VerticalLayout card = new VerticalLayout();
-        card.add(new H2(title));
+        card.add(title);
         card.add(content);
         card.setPadding(true);
         card.setSpacing(true);
         card.setWidthFull();
         card.getElement().getClassList().add("app-card");
         return card;
+    }
+
+    private void updateTexts() {
+        heading.setText(getTranslation("designSystem.heading"));
+        buttonsTitle.setText(getTranslation("designSystem.buttonsCard"));
+        badgesTitle.setText(getTranslation("designSystem.badgesCard"));
+        primaryButton.setText(getTranslation("designSystem.primary"));
+        secondaryButton.setText(getTranslation("designSystem.secondary"));
+        infoButton.setText(getTranslation("designSystem.info"));
+        successButton.setText(getTranslation("designSystem.success"));
+        warningButton.setText(getTranslation("designSystem.warning"));
+        dangerButton.setText(getTranslation("designSystem.danger"));
+        primaryBadge.setText(getTranslation("designSystem.primary"));
+        secondaryBadge.setText(getTranslation("designSystem.secondary"));
+        infoBadge.setText(getTranslation("designSystem.info"));
+        successBadge.setText(getTranslation("designSystem.success"));
+        warningBadge.setText(getTranslation("designSystem.warning"));
+        dangerBadge.setText(getTranslation("designSystem.danger"));
+    }
+
+    private void updatePageTitle() {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            ui.getPage().setTitle(getTranslation("designSystem.title"));
+        }
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        updateTexts();
+        updatePageTitle();
     }
 }

--- a/src/main/java/com/example/adminpanel/view/FormGenerationView.java
+++ b/src/main/java/com/example/adminpanel/view/FormGenerationView.java
@@ -2,8 +2,10 @@ package com.example.adminpanel.view;
 
 import com.example.adminpanel.component.GeneratedForm;
 import com.example.adminpanel.service.FormValidationService;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.router.Route;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -15,8 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * server‑side validation via a {@link FormValidationService}.
  */
 @Route(value = "forms", layout = MainLayout.class)
-@PageTitle("Forms")
-public class FormGenerationView extends VerticalLayout {
+public class FormGenerationView extends VerticalLayout implements LocaleChangeObserver {
 
     @Autowired
     public FormGenerationView(FormValidationService validationService) {
@@ -28,5 +29,18 @@ public class FormGenerationView extends VerticalLayout {
         GeneratedForm form = new GeneratedForm("user_form.json", validationService);
         add(form);
         setHorizontalComponentAlignment(Alignment.START, form);
+        updatePageTitle();
+    }
+
+    private void updatePageTitle() {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            ui.getPage().setTitle(getTranslation("forms.title"));
+        }
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        updatePageTitle();
     }
 }

--- a/src/main/java/com/example/adminpanel/view/FullGridView.java
+++ b/src/main/java/com/example/adminpanel/view/FullGridView.java
@@ -5,8 +5,10 @@ import com.example.adminpanel.component.FilterDefinition;
 import com.example.adminpanel.component.FilterablePaginatedGrid;
 import com.example.adminpanel.model.Person;
 import com.example.adminpanel.service.MockPersonService;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.router.Route;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -18,34 +20,34 @@ import java.util.List;
  * primary content on the page and should take up all remaining vertical space.
  */
 @Route(value = "full-grid", layout = MainLayout.class)
-@PageTitle("Full Grid")
-public class FullGridView extends VerticalLayout {
+public class FullGridView extends VerticalLayout implements LocaleChangeObserver {
 
     @Autowired
     public FullGridView(MockPersonService personService) {
         setSizeFull();
         setPadding(true);
         initTable(personService);
+        updatePageTitle();
     }
 
     private void initTable(MockPersonService personService) {
         // Define the columns: property name, header key and type
         List<ColumnDefinition> columns = List.of(
-                new ColumnDefinition("firstName", "First Name", String.class),
-                new ColumnDefinition("lastName", "Last Name", String.class),
-                new ColumnDefinition("email", "Email", String.class),
-                new ColumnDefinition("age", "Age", Integer.class)
+                new ColumnDefinition("firstName", "person.firstName", String.class),
+                new ColumnDefinition("lastName", "person.lastName", String.class),
+                new ColumnDefinition("email", "person.email", String.class),
+                new ColumnDefinition("age", "person.age", Integer.class)
         );
         // Define filters. Include a few additional filters for demonstration
         List<FilterDefinition> filters = List.of(
-                new FilterDefinition("firstName", "First Name", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("lastName", "Last Name", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("email", "Email", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("age", "Age", FilterDefinition.FilterType.NUMBER_RANGE, Integer.class),
-                new FilterDefinition("country", "Country", List.of("USA", "UK", "Iran"), null),
+                new FilterDefinition("firstName", "person.firstName", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("lastName", "person.lastName", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("email", "person.email", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("age", "person.age", FilterDefinition.FilterType.NUMBER_RANGE, Integer.class),
+                new FilterDefinition("country", "person.country", List.of("USA", "UK", "Iran"), null),
                 new FilterDefinition(
                         "city",
-                        "City",
+                        "person.city",
                         List.of(
                                 "USA|New York",
                                 "USA|Los Angeles",
@@ -61,5 +63,17 @@ public class FullGridView extends VerticalLayout {
         // Add grid and make it expand to consume available space
         add(grid);
         expand(grid);
+    }
+
+    private void updatePageTitle() {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            ui.getPage().setTitle(getTranslation("fullGrid.title"));
+        }
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        updatePageTitle();
     }
 }

--- a/src/main/java/com/example/adminpanel/view/LoginView.java
+++ b/src/main/java/com/example/adminpanel/view/LoginView.java
@@ -7,9 +7,10 @@ import com.vaadin.flow.component.login.LoginI18n;
 import com.vaadin.flow.component.login.LoginOverlay;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
-import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,9 +27,8 @@ import java.util.Locale;
  * already authenticated users away from the login page.
  */
 @Route(value = "login")
-@PageTitle("Login")
 @PermitAll
-public class LoginView extends VerticalLayout implements BeforeEnterObserver {
+public class LoginView extends VerticalLayout implements BeforeEnterObserver, LocaleChangeObserver {
 
     private final SecurityService securityService;
     private final LoginOverlay loginOverlay;
@@ -41,6 +41,8 @@ public class LoginView extends VerticalLayout implements BeforeEnterObserver {
         setSizeFull();
         setDefaultHorizontalComponentAlignment(FlexComponent.Alignment.CENTER);
         add(loginOverlay);
+
+        updatePageTitle();
 
         loginOverlay.addLoginListener(event -> {
             boolean success = securityService.authenticate(event.getUsername(), event.getPassword());
@@ -68,6 +70,13 @@ public class LoginView extends VerticalLayout implements BeforeEnterObserver {
         overlay.setOpened(true);
         overlay.setAction("login");
         return overlay;
+    }
+
+    private void updatePageTitle() {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            ui.getPage().setTitle(getTranslation("login.title"));
+        }
     }
 
     /**
@@ -98,5 +107,11 @@ public class LoginView extends VerticalLayout implements BeforeEnterObserver {
         if (securityService.isAuthenticated()) {
             event.forwardTo("");
         }
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        loginOverlay.setI18n(createI18n());
+        updatePageTitle();
     }
 }

--- a/src/main/java/com/example/adminpanel/view/MultipleGridsView.java
+++ b/src/main/java/com/example/adminpanel/view/MultipleGridsView.java
@@ -6,8 +6,10 @@ import com.example.adminpanel.component.FilterablePaginatedGrid;
 import com.example.adminpanel.component.FilterablePaginatedGrid.GridFeature;
 import com.example.adminpanel.model.Person;
 import com.example.adminpanel.service.MockPersonService;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.router.Route;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -20,8 +22,7 @@ import java.util.List;
  * coexist within a complex view without competing for space.
  */
 @Route(value = "multi-grids", layout = MainLayout.class)
-@PageTitle("Multiple Grids")
-public class MultipleGridsView extends VerticalLayout {
+public class MultipleGridsView extends VerticalLayout implements LocaleChangeObserver {
 
     @Autowired
     public MultipleGridsView(MockPersonService personService) {
@@ -29,21 +30,22 @@ public class MultipleGridsView extends VerticalLayout {
         setPadding(true);
         setSpacing(true);
         initTables(personService);
+        updatePageTitle();
     }
 
     private void initTables(MockPersonService personService) {
         // Define common columns and filters
         List<ColumnDefinition> columns = List.of(
-                new ColumnDefinition("firstName", "First Name", String.class),
-                new ColumnDefinition("lastName", "Last Name", String.class),
-                new ColumnDefinition("email", "Email", String.class),
-                new ColumnDefinition("age", "Age", Integer.class)
+                new ColumnDefinition("firstName", "person.firstName", String.class),
+                new ColumnDefinition("lastName", "person.lastName", String.class),
+                new ColumnDefinition("email", "person.email", String.class),
+                new ColumnDefinition("age", "person.age", Integer.class)
         );
         List<FilterDefinition> filters = List.of(
-                new FilterDefinition("firstName", "First Name", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("lastName", "Last Name", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("email", "Email", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("age", "Age", FilterDefinition.FilterType.NUMBER_RANGE, Integer.class)
+                new FilterDefinition("firstName", "person.firstName", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("lastName", "person.lastName", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("email", "person.email", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("age", "person.age", FilterDefinition.FilterType.NUMBER_RANGE, Integer.class)
         );
         // Grid 1: all features enabled, compact height
         FilterablePaginatedGrid<Person> grid1 = new FilterablePaginatedGrid<>(columns, filters, personService::fetchPage, 10);
@@ -58,5 +60,17 @@ public class MultipleGridsView extends VerticalLayout {
         grid2.setMaxHeight("400px");
         // Add both grids to the layout. Do not expand; let each control its own height
         add(grid1, grid2);
+    }
+
+    private void updatePageTitle() {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            ui.getPage().setTitle(getTranslation("multipleGrids.title"));
+        }
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        updatePageTitle();
     }
 }

--- a/src/main/java/com/example/adminpanel/view/PersonTableView.java
+++ b/src/main/java/com/example/adminpanel/view/PersonTableView.java
@@ -5,8 +5,10 @@ import com.example.adminpanel.component.FilterablePaginatedGrid;
 import com.example.adminpanel.component.FilterDefinition;
 import com.example.adminpanel.model.Person;
 import com.example.adminpanel.service.MockPersonService;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
-import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.i18n.LocaleChangeEvent;
+import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.QueryParameters;
@@ -20,8 +22,7 @@ import java.util.List;
  * Person data.  The grid supports pagination and per-column filters.
  */
 @Route(value = "persons", layout = MainLayout.class)
-@PageTitle("Persons")
-public class PersonTableView extends VerticalLayout implements BeforeEnterObserver {
+public class PersonTableView extends VerticalLayout implements BeforeEnterObserver, LocaleChangeObserver {
 
     private final MockPersonService personService;
     private FilterablePaginatedGrid<Person> grid;
@@ -32,6 +33,7 @@ public class PersonTableView extends VerticalLayout implements BeforeEnterObserv
         setSizeFull();
         setPadding(true);
         initTable();
+        updatePageTitle();
     }
 
     @Override
@@ -45,25 +47,25 @@ public class PersonTableView extends VerticalLayout implements BeforeEnterObserv
     private void initTable() {
         // Define columns: property name, header, and type
         List<ColumnDefinition> columns = List.of(
-                new ColumnDefinition("firstName", "First Name", String.class),
-                new ColumnDefinition("lastName", "Last Name", String.class),
-                new ColumnDefinition("email", "Email", String.class),
-                new ColumnDefinition("age", "Age", Integer.class)
+                new ColumnDefinition("firstName", "person.firstName", String.class),
+                new ColumnDefinition("lastName", "person.lastName", String.class),
+                new ColumnDefinition("email", "person.email", String.class),
+                new ColumnDefinition("age", "person.age", Integer.class)
         );
         // Define filters.  Include the city property even though it is not displayed
         // as a column.  Labels can later be externalised via translation keys.
         List<FilterDefinition> filters = List.of(
-                new FilterDefinition("firstName", "First Name", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("lastName", "Last Name", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("email", "Email", FilterDefinition.FilterType.TEXT, String.class),
-                new FilterDefinition("age", "Age", FilterDefinition.FilterType.NUMBER_RANGE, Integer.class),
+                new FilterDefinition("firstName", "person.firstName", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("lastName", "person.lastName", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("email", "person.email", FilterDefinition.FilterType.TEXT, String.class),
+                new FilterDefinition("age", "person.age", FilterDefinition.FilterType.NUMBER_RANGE, Integer.class),
                 // Country select: standalone list
-                new FilterDefinition("country", "Country", java.util.List.of("USA", "UK", "Iran"), null),
+                new FilterDefinition("country", "person.country", java.util.List.of("USA", "UK", "Iran"), null),
                 // City select depends on country.  Encode options with "country|city" so that
                 // the dependent filter can extract the appropriate list.
                 new FilterDefinition(
                         "city",
-                        "City",
+                        "person.city",
                         java.util.List.of(
                                 "USA|New York",
                                 "USA|Los Angeles",
@@ -90,5 +92,17 @@ public class PersonTableView extends VerticalLayout implements BeforeEnterObserv
         });
         add(grid);
         expand(grid);
+    }
+
+    private void updatePageTitle() {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            ui.getPage().setTitle(getTranslation("persons.title"));
+        }
+    }
+
+    @Override
+    public void localeChange(LocaleChangeEvent event) {
+        updatePageTitle();
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -46,8 +46,8 @@ grid.viewPlaceholder=Select a saved view
 grid.config=Table settings
 grid.export=Export
 grid.views=Views
-# %d will be replaced by selected count
-grid.selectedCount=%d selected
+# {0} will be replaced by the selected count
+grid.selectedCount={0} selected
 grid.previous=Previous
 grid.next=Next
 grid.pageInfo={0}-{1} / {2}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -67,3 +67,5 @@ email.taken=Email is already taken
 # Labels for dynamic form group controls
 form.addItem=Add item
 form.removeItem=Remove
+form.pickLocation=Pick location
+form.selectedLocation=Selected location

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -48,6 +48,16 @@ grid.export=Export
 grid.views=Views
 # %d will be replaced by selected count
 grid.selectedCount=%d selected
+grid.previous=Previous
+grid.next=Next
+grid.pageInfo={0}-{1} / {2}
+grid.filterPlaceholder=Filter
+grid.minPlaceholder=Min
+grid.maxPlaceholder=Max
+grid.fromPlaceholder=From
+grid.toPlaceholder=To
+grid.selectPlaceholder=Select
+grid.defaultViewName=view
 
 # Menu group for examples and demonstration pages
 menu.examples=Examples
@@ -69,3 +79,36 @@ form.addItem=Add item
 form.removeItem=Remove
 form.pickLocation=Pick location
 form.selectedLocation=Selected location
+form.noLocationSelected=No location selected yet.
+form.location.searchPlaceholder=Search for a place
+form.location.search=Search
+form.location.searching=Searching…
+form.location.noResults=No results found.
+form.location.fetchError=Unable to fetch locations. Please try again.
+form.location.noSelection=No location selected yet.
+form.location.selectedLabel=Selected location:
+
+# Person grid labels
+person.firstName=First name
+person.lastName=Last name
+person.email=Email
+person.age=Age
+person.country=Country
+person.city=City
+
+# View titles
+persons.title=Persons
+fullGrid.title=Full Grid
+compactGrid.title=Compact Grid
+multipleGrids.title=Multiple Grids
+forms.title=Forms
+designSystem.title=Design System
+designSystem.heading=Color palette preview
+designSystem.buttonsCard=Buttons
+designSystem.badgesCard=Badges
+designSystem.primary=Primary
+designSystem.secondary=Secondary
+designSystem.info=Info
+designSystem.success=Success
+designSystem.warning=Warning
+designSystem.danger=Danger

--- a/src/main/resources/messages_fa.properties
+++ b/src/main/resources/messages_fa.properties
@@ -42,7 +42,7 @@ grid.exportExcel=خروجی اکسل
 grid.saveView=ذخیره نما
 grid.view=نما
 grid.viewPlaceholder=انتخاب نما
-grid.selectedCount=%d انتخاب شده
+grid.selectedCount={0} انتخاب شده
 # Labels for table configuration menu
 grid.config=پیکربندی جدول
 grid.export=خروجی

--- a/src/main/resources/messages_fa.properties
+++ b/src/main/resources/messages_fa.properties
@@ -47,6 +47,16 @@ grid.selectedCount=%d انتخاب شده
 grid.config=پیکربندی جدول
 grid.export=خروجی
 grid.views=نماها
+grid.previous=قبلی
+grid.next=بعدی
+grid.pageInfo={0}-{1} / {2}
+grid.filterPlaceholder=فیلتر
+grid.minPlaceholder=حداقل
+grid.maxPlaceholder=حداکثر
+grid.fromPlaceholder=از
+grid.toPlaceholder=تا
+grid.selectPlaceholder=انتخاب
+grid.defaultViewName=نما
 
 # Menu group for examples and demonstration pages
 menu.examples=نمونه‌ها
@@ -68,3 +78,36 @@ form.addItem=افزودن مورد
 form.removeItem=حذف
 form.pickLocation=انتخاب موقعیت
 form.selectedLocation=موقعیت انتخاب‌شده
+form.noLocationSelected=هنوز موقعیتی انتخاب نشده است.
+form.location.searchPlaceholder=جستجوی مکان
+form.location.search=جستجو
+form.location.searching=در حال جستجو…
+form.location.noResults=موردی یافت نشد.
+form.location.fetchError=امکان دریافت مکان‌ها نیست. دوباره تلاش کنید.
+form.location.noSelection=هنوز موقعیتی انتخاب نشده است.
+form.location.selectedLabel=مکان انتخاب‌شده:
+
+# Person grid labels
+person.firstName=نام
+person.lastName=نام خانوادگی
+person.email=ایمیل
+person.age=سن
+person.country=کشور
+person.city=شهر
+
+# View titles
+persons.title=افراد
+fullGrid.title=نمای کامل جدول
+compactGrid.title=جدول فشرده
+multipleGrids.title=چند جدول
+forms.title=فرم‌ها
+designSystem.title=سیستم طراحی
+designSystem.heading=پیش‌نمایش رنگ‌ها
+designSystem.buttonsCard=دکمه‌ها
+designSystem.badgesCard=نشان‌ها
+designSystem.primary=اصلی
+designSystem.secondary=ثانویه
+designSystem.info=اطلاعات
+designSystem.success=موفق
+designSystem.warning=هشدار
+designSystem.danger=خطر

--- a/src/main/resources/messages_fa.properties
+++ b/src/main/resources/messages_fa.properties
@@ -66,3 +66,5 @@ email.taken=ایمیل قبلاً ثبت شده است
 # Labels for dynamic form group controls
 form.addItem=افزودن مورد
 form.removeItem=حذف
+form.pickLocation=انتخاب موقعیت
+form.selectedLocation=موقعیت انتخاب‌شده


### PR DESCRIPTION
## Summary
- replace the plain location picker with a Leaflet-powered experience that initializes the map reliably and keeps it sized within dialogs
- add an inline search workflow that queries Nominatim and allows users to select results to position the marker
- provide clear feedback for the currently selected coordinates and keep the server-side listener in sync with marker moves

## Testing
- `mvn -q -DskipITs test` *(fails: Non-resolvable parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68caf21cf82083329a477acc20577407