### PR TITLE
Improve navigation dropdown styling and behavior

### DIFF
--- a/frontend/themes/app/foundations.css
+++ b/frontend/themes/app/foundations.css
@@ -109,59 +109,56 @@ vaadin-app-layout::part(navbar) {
 }
 
 vaadin-vertical-layout.app-drawer {
-  padding: var(--space-6) var(--space-4);
+  padding: var(--space-6) var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-4);
   box-sizing: border-box;
+  background: var(--surface-subtle);
 }
 
 .nav-section-title {
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--text-muted);
-  margin: 0;
-}
-
-vaadin-vertical-layout.nav-section {
-  gap: var(--space-3);
-  padding: 0;
+  color: var(--text-secondary);
+  margin: var(--space-3) var(--space-3) var(--space-2);
+  padding-inline: var(--space-1);
 }
 
 vaadin-vertical-layout.nav-group {
-  padding: 0;
+  padding: var(--space-1) var(--space-2) var(--space-3);
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-}
-
-.nav-divider {
-  height: 1px;
-  background: var(--divider-strong);
-  opacity: 0.4;
+  border-radius: var(--radius-l);
 }
 
 .nav-row {
   width: 100%;
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-3);
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-m);
   color: var(--text-secondary);
-  transition: background-color 120ms ease, color 120ms ease;
+  font-weight: var(--font-weight-medium);
+  transition: background-color 140ms ease, color 140ms ease;
 }
 
-.nav-row:hover {
-  background: color-mix(in srgb, var(--lumo-primary-color) 8%, transparent);
-  color: var(--lumo-body-text-color);
+.nav-row:hover,
+.nav-row:focus-visible {
+  background: color-mix(in srgb, var(--lumo-primary-color) 10%, transparent);
+  color: var(--text-primary);
 }
 
 .nav-row__icon {
   flex: 0 0 auto;
-  margin-inline-end: var(--space-2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
 }
 
 .nav-row__label {
@@ -172,11 +169,54 @@ vaadin-vertical-layout.nav-group {
   white-space: nowrap;
 }
 
+.nav-row--summary {
+  padding-inline: var(--space-3);
+}
+
+.nav-row--leaf {
+  padding-inline: var(--space-3);
+}
+
+.nav-row--child {
+  padding-inline-start: calc(var(--space-3) + var(--space-2));
+}
+
 .nav-children {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  padding-inline-start: var(--space-2);
+  margin-inline-start: var(--space-2);
+  padding-inline-start: var(--space-3);
+  border-inline-start: 1px solid color-mix(in srgb, var(--divider-subtle) 60%, transparent);
+}
+
+.nav-row__caret {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: var(--text-muted);
+  transition: transform 160ms ease, color 140ms ease;
+}
+
+.nav-row:hover .nav-row__caret,
+.nav-row:focus-visible .nav-row__caret {
+  color: currentColor;
+}
+
+.nav-row__caret vaadin-icon {
+  width: 100%;
+  height: 100%;
+}
+
+[dir='ltr'] .nav-row__caret--closed {
+  transform: rotate(-90deg);
+}
+
+[dir='rtl'] .nav-row__caret--closed {
+  transform: rotate(90deg);
 }
 
 vaadin-details.nav-accordion::part(content) {
@@ -188,8 +228,8 @@ vaadin-details.nav-accordion::part(summary) {
   padding: 0;
 }
 
-.nav-accordion .nav-row--summary {
-  padding-inline-end: var(--space-6);
+vaadin-details.nav-accordion::part(summary)::before {
+  display: none;
 }
 
 .app-drawer vaadin-button {


### PR DESCRIPTION
## Summary
- ensure the header profile menu and grid configuration dropdowns apply a minimum overlay width so the panels are wider than their triggers
- rebuild the drawer navigation rows to align icons/text consistently and place a chevron at the end that responds to RTL locales
- refresh the drawer theme styles for higher contrast section labels, refined spacing, and RTL-aware caret rotation

## Testing
- mvn -q -DskipTests package *(fails: cannot resolve Spring Boot parent due to offline Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd1d0c56c83328564dc3a64f4ebe2