### PR TITLE
Ensure RTL locale initialization uses shared helper

### DIFF
--- a/src/main/java/com/example/adminpanel/config/UiLocaleInitializer.java
+++ b/src/main/java/com/example/adminpanel/config/UiLocaleInitializer.java
@@ -1,5 +1,6 @@
 package com.example.adminpanel.config;
 
+import com.example.adminpanel.i18n.LocaleDirectionService;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinServiceInitListener;
@@ -9,6 +10,12 @@ import java.util.Locale;
 
 @Component
 public class UiLocaleInitializer implements VaadinServiceInitListener {
+    private final LocaleDirectionService localeDirectionService;
+
+    public UiLocaleInitializer(LocaleDirectionService localeDirectionService) {
+        this.localeDirectionService = localeDirectionService;
+    }
+
     @Override
     public void serviceInit(ServiceInitEvent event) {
         // Use VaadinService (event.getSource()) to register a UI init listener
@@ -16,10 +23,7 @@ public class UiLocaleInitializer implements VaadinServiceInitListener {
             UI ui = uiInit.getUI();
             Locale pref = (Locale) ui.getSession().getAttribute("preferred-locale");
             Locale locale = pref != null ? pref : new Locale("fa");
-            ui.setLocale(locale);
-            String lang = locale.getLanguage();
-            ui.getElement().setAttribute("lang", lang);
-            ui.getElement().setAttribute("dir", "fa".equals(lang) ? "rtl" : "ltr");
+            localeDirectionService.applyLocale(ui, locale);
         });
     }
 }

--- a/src/main/java/com/example/adminpanel/i18n/LocaleDirectionService.java
+++ b/src/main/java/com/example/adminpanel/i18n/LocaleDirectionService.java
@@ -1,0 +1,62 @@
+package com.example.adminpanel.i18n;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.Page;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+import java.util.Objects;
+
+@Service
+public class LocaleDirectionService {
+
+    private static final String RTL_LANGUAGE = "fa";
+
+    public void applyLocale(UI ui, Locale locale) {
+        if (ui == null) {
+            return;
+        }
+        Locale target = locale != null ? locale : Locale.ENGLISH;
+        if (!Objects.equals(ui.getLocale(), target)) {
+            ui.setLocale(target);
+        } else {
+            // Even if locale didn't change, ensure direction stays in sync.
+            applyDirection(ui, target);
+            return;
+        }
+        applyDirection(ui, target);
+    }
+
+    public void applyDirection(UI ui) {
+        if (ui == null) {
+            return;
+        }
+        applyDirection(ui, ui.getLocale());
+    }
+
+    private void applyDirection(UI ui, Locale locale) {
+        Locale target = locale != null ? locale : Locale.ENGLISH;
+        boolean rtl = RTL_LANGUAGE.equalsIgnoreCase(target.getLanguage());
+        String lang = target.getLanguage();
+        String dir = rtl ? "rtl" : "ltr";
+
+        ui.getElement().setAttribute("lang", lang);
+        ui.getElement().setAttribute("dir", dir);
+
+        if (rtl) {
+            ui.getElement().getStyle().set("--lumo-font-family", "'Vazir', sans-serif");
+        } else {
+            ui.getElement().getStyle().remove("--lumo-font-family");
+        }
+
+        Page page = ui.getPage();
+        page.executeJs(
+                "document.documentElement.setAttribute('dir',$0);" +
+                        "document.body.setAttribute('dir',$0);" +
+                        "document.documentElement.setAttribute('lang',$1);" +
+                        "document.body.setAttribute('lang',$1);",
+                dir,
+                lang
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `LocaleDirectionService` to apply locale, language, and direction attributes consistently
- refactor `MainLayout` to use the shared service when toggling the language and reacting to locale changes
- update the UI initializer to reuse the shared service so initial loads apply RTL settings the same way as runtime toggles

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6339a7ec833288c5bfe9d8fa47e7