### PR TITLE
Fix WrapMode import for GeneratedForm

### DIFF
--- a/src/main/java/com/example/adminpanel/component/GeneratedForm.java
+++ b/src/main/java/com/example/adminpanel/component/GeneratedForm.java
@@ -18,7 +18,7 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout.WrapMode;
+import com.vaadin.flow.component.orderedlayout.FlexLayout.WrapMode;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextField;


### PR DESCRIPTION
## Summary
- fix the GeneratedForm import to use FlexLayout.WrapMode so the class compiles against Vaadin 24

## Testing
- mvn -DskipTests compile *(fails: cannot download Spring Boot parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3de41f68833293ef863160e9ede1