### PR TITLE
Restore GeneratedForm flex wrapping with Vaadin 24 API

### DIFF
--- a/src/main/java/com/example/adminpanel/component/GeneratedForm.java
+++ b/src/main/java/com/example/adminpanel/component/GeneratedForm.java
@@ -18,7 +18,7 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout.WrapMode;
+import com.vaadin.flow.component.orderedlayout.FlexLayout.FlexWrap;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextField;
@@ -216,7 +216,7 @@ public class GeneratedForm extends VerticalLayout implements LocaleChangeObserve
                     }
                 }
                 boolean wrap = layoutConfig != null && layoutConfig.has("wrap") && layoutConfig.get("wrap").asBoolean(false);
-                row.setWrapMode(wrap ? WrapMode.WRAP : WrapMode.NO_WRAP);
+                row.setFlexWrap(wrap ? FlexWrap.WRAP : FlexWrap.NOWRAP);
                 fieldContainer = row;
             }
             case "vertical" -> {


### PR DESCRIPTION
## Summary
- adjust GeneratedForm to import FlexLayout.FlexWrap and call setFlexWrap so the horizontal layout uses the Vaadin 24 flexbox API

## Testing
- mvn -DskipTests compile *(fails: cannot download Spring Boot parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3de41f68833293ef863160e9ede1