### PR TITLE
Restore GeneratedForm flex wrapping with Vaadin 24 API

### DIFF
--- a/src/main/java/com/example/adminpanel/component/GeneratedForm.java
+++ b/src/main/java/com/example/adminpanel/component/GeneratedForm.java
@@ -18,7 +18,6 @@ import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
 import com.vaadin.flow.component.orderedlayout.FlexComponent.JustifyContentMode;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout.WrapMode;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextField;
@@ -216,7 +215,7 @@ public class GeneratedForm extends VerticalLayout implements LocaleChangeObserve
                     }
                 }
                 boolean wrap = layoutConfig != null && layoutConfig.has("wrap") && layoutConfig.get("wrap").asBoolean(false);
-                row.setWrapMode(wrap ? WrapMode.WRAP : WrapMode.NO_WRAP);
+                row.getStyle().set("flex-wrap", wrap ? "wrap" : "nowrap");
                 fieldContainer = row;
             }
             case "vertical" -> {

--- a/src/main/java/com/example/adminpanel/component/JalaliDateTimePicker.java
+++ b/src/main/java/com/example/adminpanel/component/JalaliDateTimePicker.java
@@ -130,7 +130,7 @@ public class JalaliDateTimePicker extends AbstractField<JalaliDateTimePicker, Lo
     }
 
     @Override
-    protected void onEnabledStateChanged(boolean enabled) {
+    public void onEnabledStateChanged(boolean enabled) {
         super.onEnabledStateChanged(enabled);
         getElement().setProperty("disabled", !enabled);
     }


### PR DESCRIPTION
## Summary
- adjust GeneratedForm to set the flex-wrap style directly on HorizontalLayout so wrapping works without unsupported APIs
- keep JalaliDateTimePicker's enabled-state override public to match the Vaadin component contract

## Testing
- mvn -DskipTests compile *(fails: cannot download Spring Boot parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ce3de41f68833293ef863160e9ede1