### PR TITLE
Fix boundary detection boolean handling

### DIFF
--- a/frontend/components/jalali-date-time-picker.ts
+++ b/frontend/components/jalali-date-time-picker.ts
@@ -320,8 +320,9 @@ export class JalaliDateTimePicker extends LitElement {
   private isAtBoundary(parts: DateParts): boolean {
     const min = this.minParts;
     const max = this.maxParts;
-    return (min && this.compareParts(parts, min) === 0)
-      || (max && this.compareParts(parts, max) === 0);
+    const isAtMin = min !== null && this.compareParts(parts, min) === 0;
+    const isAtMax = max !== null && this.compareParts(parts, max) === 0;
+    return isAtMin || isAtMax;
   }
 
   private arePartsEqual(a: DateParts, b: DateParts): boolean {


### PR DESCRIPTION
## Summary
- ensure jalali date picker boundary detection returns a strict boolean to satisfy the TypeScript build

## Testing
- mvn -q -DskipTests package *(fails: unable to reach Maven Central in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4a48044c83328bee2f065c7b4729