### PR TITLE
fix: remove duplicate method definition causing Vite build failure

### DIFF
--- a/frontend/components/jalali-date-time-picker.ts
+++ b/frontend/components/jalali-date-time-picker.ts
@@ -1428,13 +1428,6 @@ export class JalaliDateTimePicker extends LitElement {
     return this.mode === 'date' ? 'Select date' : 'Select date & time';
   }
 
-  private getOpenButtonLabel(): string {
-    if (this.openButtonLabel && this.openButtonLabel.trim().length > 0) {
-      return this.openButtonLabel;
-    }
-    return this.mode === 'date' ? 'Select date' : 'Select date & time';
-  }
-
   private getMinuteOptions(): number[] {
     const step = this.getMinuteStep();
     const options: number[] = [];


### PR DESCRIPTION
## Summary
- remove the duplicate `getOpenButtonLabel` method in the Jalali date time picker component to restore a single implementation

## Testing
- `mvn -Pproduction -DskipTests package` *(fails: unable to resolve parent POM because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4043757c483328aa5c10746e2b794